### PR TITLE
Allow custom onDragOver and onDragLeave to be injected as props

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,15 +26,17 @@ var Dropzone = React.createClass({
   },
 
   onDragOver: function(e) {
-    e.preventDefault();
-    e.dataTransfer.dropEffect = "copy";
+    if( !this.state.isDragActive ) {
+      e.preventDefault();
+      e.dataTransfer.dropEffect = "copy";
 
-    this.setState({
-      isDragActive: true
-    });
+      this.setState({
+        isDragActive: true
+      });
 
-    if (this.props.onDragOver){
-      this.props.onDragOver()
+      if (this.props.onDragOver) {
+        this.props.onDragOver()
+      }
     }
   },
 

--- a/index.js
+++ b/index.js
@@ -26,7 +26,6 @@ var Dropzone = React.createClass({
   },
 
   onDragOver: function(e) {
-    if( !this.state.isDragActive ) {
       e.preventDefault();
       e.dataTransfer.dropEffect = "copy";
 
@@ -34,6 +33,7 @@ var Dropzone = React.createClass({
         isDragActive: true
       });
 
+    if( !this.state.isDragActive ) {
       if (this.props.onDragOver) {
         this.props.onDragOver()
       }

--- a/index.js
+++ b/index.js
@@ -10,13 +10,19 @@ var Dropzone = React.createClass({
   propTypes: {
     onDrop: React.PropTypes.func.isRequired,
     size: React.PropTypes.number,
-    style: React.PropTypes.object
+    style: React.PropTypes.object,
+    onDragOver: React.PropTypes.func,
+    onDragLeave: React.PropTypes.func
   },
 
   onDragLeave: function(e) {
     this.setState({
       isDragActive: false
     });
+
+    if (this.props.onDragLeave){
+      this.props.onDragLeave()
+    }
   },
 
   onDragOver: function(e) {
@@ -26,6 +32,10 @@ var Dropzone = React.createClass({
     this.setState({
       isDragActive: true
     });
+
+    if (this.props.onDragOver){
+      this.props.onDragOver()
+    }
   },
 
   onDrop: function(e) {

--- a/index.js
+++ b/index.js
@@ -26,12 +26,12 @@ var Dropzone = React.createClass({
   },
 
   onDragOver: function(e) {
-      e.preventDefault();
-      e.dataTransfer.dropEffect = "copy";
+    e.preventDefault();
+    e.dataTransfer.dropEffect = "copy";
 
-      this.setState({
-        isDragActive: true
-      });
+    this.setState({
+      isDragActive: true
+    });
 
     if( !this.state.isDragActive ) {
       if (this.props.onDragOver) {


### PR DESCRIPTION
This now works. Potentially, instead of adding to onDragOver, we could make an onDragEnter which would have the same effect (I think) as this PR. 