### PR TITLE
Turn off onClick support by default

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,12 @@
 var React = require('react');
 
 var Dropzone = React.createClass({
+  getDefaultProps: function() {
+    return {
+      supportClick: true
+    };
+  },
+
   getInitialState: function() {
     return {
       isDragActive: false
@@ -10,7 +16,8 @@ var Dropzone = React.createClass({
   propTypes: {
     onDrop: React.PropTypes.func.isRequired,
     size: React.PropTypes.number,
-    style: React.PropTypes.object
+    style: React.PropTypes.object,
+    supportClick: React.PropTypes.bool
   },
 
   onDragLeave: function(e) {
@@ -53,7 +60,9 @@ var Dropzone = React.createClass({
   },
 
   onClick: function () {
-    this.refs.fileInput.getDOMNode().click();
+    if (this.props.supportClick === true) {
+      this.refs.fileInput.getDOMNode().click();
+    }
   },
 
   render: function() {


### PR DESCRIPTION
Just used this plugin (which is awesome BTW!) on a project where we wanted drag and drop support but not clicking, and made this change to support that. It means you have to pass in `supportClick={true}` to turn the click support. What do you think? Be happy to change the approach but probably quite useful to be able to customise this stuff?