### PR TITLE
Add optional event parameter to onDrop

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ var Dropzone = React.createClass({
 
     if (this.props.onDrop) {
       files = Array.prototype.slice.call(files);
-      this.props.onDrop(files);
+      this.props.onDrop(files, e);
     }
   },
 


### PR DESCRIPTION
I figured the user-written onDrop method could use the event. I myself needed it for some jQuery callbacks. This modification doesn't break any existing functionality - `onDrop` methods written with the single `files` parameter will continue to work - just that including an extra event will allow users access to it.