### PR TITLE
Support setting multiple to false to enable single file drop/pick

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,8 @@ var React = require('react');
 var Dropzone = React.createClass({
   getDefaultProps: function() {
     return {
-      supportClick: true
+      supportClick: true,
+      multiple: true
     };
   },
 
@@ -18,7 +19,8 @@ var Dropzone = React.createClass({
     size: React.PropTypes.number,
     style: React.PropTypes.object,
     supportClick: React.PropTypes.bool,
-    accept: React.PropTypes.string
+    accept: React.PropTypes.string,
+    multiple: React.PropTypes.bool
   },
 
   onDragLeave: function(e) {
@@ -49,13 +51,14 @@ var Dropzone = React.createClass({
     } else if (e.target) {
       files = e.target.files;
     }
-
-    for (var i = 0; i < files.length; i++) {
+    
+    var maxFiles = (this.props.multiple) ? files.length : 1;
+    for (var i = 0; i < maxFiles; i++) {
       files[i].preview = URL.createObjectURL(files[i]);
     }
 
     if (this.props.onDrop) {
-      files = Array.prototype.slice.call(files);
+      files = Array.prototype.slice.call(files, 0, maxFiles);
       this.props.onDrop(files);
     }
   },
@@ -86,7 +89,7 @@ var Dropzone = React.createClass({
 
     return (
         React.createElement("div", {className: className, style: style, onClick: this.onClick, onDragLeave: this.onDragLeave, onDragOver: this.onDragOver, onDrop: this.onDrop},
-            React.createElement("input", {style: {display: 'none'}, type: "file", multiple: true, ref: "fileInput", onChange: this.onDrop, accept: this.props.accept}),
+            React.createElement("input", {style: {display: 'none'}, type: "file", multiple: this.props.multiple, ref: "fileInput", onChange: this.onDrop, accept: this.props.accept}),
             this.props.children
         )
     );


### PR DESCRIPTION
Example: <Dropzone multiple={false} onDrop={this.onDrop} size={150}></Dropzone>

Currently just takes the first file in the dropped array if the user drops multiple files. (I don't think it's good to disallow dropping if the user tries to drop several files on the drop zone.)