### PR TITLE
adding a file input name attribute, necessary for some file upload plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ var DropzoneDemo = React.createClass({
     render: function () {
       return (
           <div>
-            <Dropzone onDrop={this.onDrop} size={150} >
+            <Dropzone onDrop={this.onDrop} size={150} inputName='myFileUpload' >
               <div>Try dropping some files here, or click to select files to upload.</div>
             </Dropzone>
           </div>
@@ -53,6 +53,9 @@ The `onDrop` provides you with an array of [Files](https://developer.mozilla.org
         req.end(callback);
     }
 ```
+The `onDrop` provides you with an array of [Files](https://developer.mozilla.org/en-US/docs/Web/API/File) which you can then send to a server. For example, with [SuperAgent](https://github.com/visionmedia/superagent) as a http/ajax library:
+
+The `inputName` attribute sets the file input name. This maybe useful for some other plugins for file upload. By default its `fileInput`.
 
 Starting `v1.1`, you can now immediately show a preview of the dropped file while it uploads. The `file.preview` property can be specified as the image source: `<img src={file.preview} />` to display a preview of the image dropped.
 

--- a/index.js
+++ b/index.js
@@ -3,7 +3,8 @@ var React = require('react');
 var Dropzone = React.createClass({
   getDefaultProps: function() {
     return {
-      supportClick: true
+      supportClick: true,
+      inputName: 'fileInput'
     };
   },
 
@@ -86,7 +87,7 @@ var Dropzone = React.createClass({
 
     return (
         React.createElement("div", {className: className, style: style, onClick: this.onClick, onDragLeave: this.onDragLeave, onDragOver: this.onDragOver, onDrop: this.onDrop},
-            React.createElement("input", {style: {display: 'none'}, type: "file", multiple: true, ref: "fileInput", onChange: this.onDrop, accept: this.props.accept}),
+            React.createElement("input", {style: {display: 'none'}, type: "file", multiple: true, name: this.props.inputName, ref: "fileInput", onChange: this.onDrop, accept: this.props.accept}),
             this.props.children
         )
     );


### PR DESCRIPTION
Please see if this seems appropriate to you. Just tried using with some other file upload plugin and it wasn't working because `name` attribute in the input tag was not present.