### PR TITLE
Clear out file input before click to allow user to select same file again

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,7 +70,9 @@ var Dropzone = React.createClass({
   },
 
   open: function() {
-    React.findDOMNode(this.refs.fileInput).click();
+    var fileInput = React.findDOMNode(this.refs.fileInput);
+    fileInput.value = null;
+    fileInput.click();
   },
 
   render: function() {


### PR DESCRIPTION
Inputs with a type of `file` store the file path in their value and if you select the same file again, you need to clear out the value so that the correct drop events can retrigger. Ran into this issue when a user was adding a file, deleting it via our file manager and then re-adding that file afterwards. This simply clears the input value before attempting to click it.