### PR TITLE
Optionally disable style object in a clearly explicit manner and control size better with `width` and `height` props.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ Usage
 
 Simply `require('react-dropzone')` and specify an `onDrop` method that accepts an array of dropped files. You can customize the content of the Dropzone by specifying children to the component.
 
-You can specify a `style` object to apply some basic styles to the `Dropzone` component. The style object includes `width`, `height`, and `borderStyle` properties (`width` and `height` can be integers, whereas `borderStyle` can be one of any CSS border-style).
+You can specify a `style` object to apply some basic styles to the `Dropzone` component, or alternatively use the `className` property to style the component with custom CSS.
 
-You can also specify a `size` property which is an integer that sets both `style.width` and `style.height` to the same value.
+If no `style` or `className` properties are defined, the style object will default to the `width` and `height` properties (or `100px` if they aren't defined) along with a `borderStyle` of "solid" or "dashed" depending on if drag actions are taking place.
 
-Finally, you can set `noDefaultStyles` to *true* to disable the default `style` object completely and allow your custom CSS from `className` to take over (see below).
+You can alternatively specify a `size` property which is an integer that sets both `style.width` and `style.height` to the same value.
 
 ```jsx
 
@@ -90,52 +90,6 @@ var DropzoneDemo = React.createClass({
             <button type="button" onClick={this.onOpenClick}>
                 Open Dropzone
             </button>
-          </div>
-      );
-    }
-});
-
-React.render(<DropzoneDemo />, document.body);
-```
-
-Custom CSS
-==========
-
-You may want to use your own, custom, CSS styles to control how the Dropzone element looks. You can add any classes you like to the `className` property and then disable the default style object by setting `noDefaultStyles` to *true*.
-
-For example, your custom stylesheet might have this class:
-
-```css
-
-.myCustomClass {
-  width: 480px;
-  height: 640px;
-  border: 3px dotted rgba(0, 0, 0, .5);
-  background-color: #fefefe;
-  color: #333;
-  cursor: pointer;
-}
-```
-
-You can apply your custom class to the Dropzone element like this:
-
-```jsx
-
-/** @jsx React.DOM */
-var React = require('react');
-var Dropzone = require('react-dropzone');
-
-var DropzoneDemo = React.createClass({
-    onDrop: function (files) {
-      console.log('Received files: ', files);
-    },
-
-    render: function () {
-      return (
-          <div>
-            <Dropzone className="myCustomClass" noDefaultStyles={true} onDrop={this.onDrop}>
-              <div>Try dropping some files here, or click to select files to upload.</div>
-            </Dropzone>
           </div>
       );
     }

--- a/README.md
+++ b/README.md
@@ -12,7 +12,11 @@ Usage
 
 Simply `require('react-dropzone')` and specify an `onDrop` method that accepts an array of dropped files. You can customize the content of the Dropzone by specifying children to the component.
 
-You can also specify a `style` object to apply to the `Dropzone` component. Optionally pass in a `size` property to configure the size of the Dropzone.
+You can specify a `style` object to apply some basic styles to the `Dropzone` component. The style object includes `width`, `height`, and `borderStyle` properties (`width` and `height` can be integers, whereas `borderStyle` can be one of any CSS border-style).
+
+You can also specify a `size` property which is an integer that sets both `style.width` and `style.height` to the same value.
+
+Finally, you can set `noDefaultStyles` to *true* to disable the default `style` object completely and allow your custom CSS from `className` to take over (see below).
 
 ```jsx
 
@@ -28,7 +32,7 @@ var DropzoneDemo = React.createClass({
     render: function () {
       return (
           <div>
-            <Dropzone onDrop={this.onDrop} size={150} >
+            <Dropzone onDrop={this.onDrop} width={150} height={100}>
               <div>Try dropping some files here, or click to select files to upload.</div>
             </Dropzone>
           </div>
@@ -38,7 +42,6 @@ var DropzoneDemo = React.createClass({
 
 React.render(<DropzoneDemo />, document.body);
 ```
-
 
 Using `react-dropzone` is similar to using a file form field, but instead of getting the `files` property from the field, you listen to the `onDrop` callback to handle the files. Simple explanation here: http://abandon.ie/notebook/simple-file-uploads-using-jquery-ajax
 
@@ -87,6 +90,52 @@ var DropzoneDemo = React.createClass({
             <button type="button" onClick={this.onOpenClick}>
                 Open Dropzone
             </button>
+          </div>
+      );
+    }
+});
+
+React.render(<DropzoneDemo />, document.body);
+```
+
+Custom CSS
+==========
+
+You may want to use your own, custom, CSS styles to control how the Dropzone element looks. You can add any classes you like to the `className` property and then disable the default style object by setting `noDefaultStyles` to *true*.
+
+For example, your custom stylesheet might have this class:
+
+```css
+
+.myCustomClass {
+  width: 480px;
+  height: 640px;
+  border: 3px dotted rgba(0, 0, 0, .5);
+  background-color: #fefefe;
+  color: #333;
+  cursor: pointer;
+}
+```
+
+You can apply your custom class to the Dropzone element like this:
+
+```jsx
+
+/** @jsx React.DOM */
+var React = require('react');
+var Dropzone = require('react-dropzone');
+
+var DropzoneDemo = React.createClass({
+    onDrop: function (files) {
+      console.log('Received files: ', files);
+    },
+
+    render: function () {
+      return (
+          <div>
+            <Dropzone className="myCustomClass" noDefaultStyles={true} onDrop={this.onDrop}>
+              <div>Try dropping some files here, or click to select files to upload.</div>
+            </Dropzone>
           </div>
       );
     }

--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ var Dropzone = React.createClass({
     width: React.PropTypes.number,
     height: React.PropTypes.number,
     style: React.PropTypes.object,
+    noDefaultStyles: React.PropTypes.bool,
     supportClick: React.PropTypes.bool,
     accept: React.PropTypes.string,
     multiple: React.PropTypes.bool
@@ -95,12 +96,14 @@ var Dropzone = React.createClass({
       className += ' active';
     }
 
-    var style = this.props.style || {
-      width: this.props.width || this.props.size || 100,
-      height: this.props.height || this.props.size || 100,
-      borderStyle: this.state.isDragActive ? 'solid' : 'dashed'
-    };
-
+    var style = {};
+    if (!this.props.noDefaultStyles) {
+      var style = this.props.style || {
+        width: this.props.width || this.props.size || 100,
+        height: this.props.height || this.props.size || 100,
+        borderStyle: this.state.isDragActive ? 'solid' : 'dashed'
+      };
+    }
 
     return (
       React.createElement(

--- a/index.js
+++ b/index.js
@@ -103,10 +103,31 @@ var Dropzone = React.createClass({
 
 
     return (
-        React.createElement('div', {className: className, style: style, onClick: this.onClick, onDragLeave: this.onDragLeave, onDragOver: this.onDragOver, onDrop: this.onDrop},
-            React.createElement('input', {style: {display: 'none'}, type: 'file', multiple: this.props.multiple, ref: 'fileInput', onChange: this.onDrop, accept: this.props.accept}),
-            this.props.children
-        )
+      React.createElement(
+        'div',
+        {
+          className: className,
+          style: style,
+          onClick: this.onClick,
+          onDragLeave: this.onDragLeave,
+          onDragOver: this.onDragOver,
+          onDrop: this.onDrop
+        },
+        React.createElement(
+          'input',
+          {
+            style: {
+              display: 'none'
+            },
+            type: 'file',
+            multiple: this.props.multiple,
+            ref: 'fileInput',
+            onChange: this.onDrop,
+            accept: this.props.accept
+          }
+        ),
+        this.props.children
+      )
     );
   }
 

--- a/index.js
+++ b/index.js
@@ -22,7 +22,6 @@ var Dropzone = React.createClass({
     width: React.PropTypes.number,
     height: React.PropTypes.number,
     style: React.PropTypes.object,
-    noDefaultStyles: React.PropTypes.bool,
     supportClick: React.PropTypes.bool,
     accept: React.PropTypes.string,
     multiple: React.PropTypes.bool
@@ -96,14 +95,11 @@ var Dropzone = React.createClass({
       className += ' active';
     }
 
-    var style = {};
-    if (!this.props.noDefaultStyles) {
-      var style = this.props.style || {
-        width: this.props.width || this.props.size || 100,
-        height: this.props.height || this.props.size || 100,
-        borderStyle: this.state.isDragActive ? 'solid' : 'dashed'
-      };
-    }
+    var style = this.props.style || {
+      width: this.props.width || this.props.size || 100,
+      height: this.props.height || this.props.size || 100,
+      borderStyle: this.state.isDragActive ? 'solid' : 'dashed'
+    };
 
     return (
       React.createElement(

--- a/index.js
+++ b/index.js
@@ -89,21 +89,24 @@ var Dropzone = React.createClass({
   },
 
   render: function() {
-
     var className = this.props.className || 'dropzone';
     if (this.state.isDragActive) {
       className += ' active';
     }
 
-    var style = this.props.style || {
-      width: this.props.width || this.props.size || 100,
-      height: this.props.height || this.props.size || 100,
-      borderStyle: this.state.isDragActive ? 'solid' : 'dashed'
-    };
+    var style = {};
+    if (this.props.style) { // user-defined inline styles take priority
+      style = this.props.style;
+    } else if (!this.props.className) { // if no class or inline styles defined, use defaults
+      style = {
+        width: this.props.width || this.props.size || 100,
+        height: this.props.height || this.props.size || 100,
+        borderStyle: this.state.isDragActive ? 'solid' : 'dashed'
+      };
+    }
 
     return (
-      React.createElement(
-        'div',
+      React.createElement('div',
         {
           className: className,
           style: style,
@@ -112,12 +115,9 @@ var Dropzone = React.createClass({
           onDragOver: this.onDragOver,
           onDrop: this.onDrop
         },
-        React.createElement(
-          'input',
+        React.createElement('input',
           {
-            style: {
-              display: 'none'
-            },
+            style: { display: 'none' },
             type: 'file',
             multiple: this.props.multiple,
             ref: 'fileInput',

--- a/index.js
+++ b/index.js
@@ -19,6 +19,8 @@ var Dropzone = React.createClass({
     onDragOver: React.PropTypes.func,
     onDragLeave: React.PropTypes.func,
     size: React.PropTypes.number,
+    width: React.PropTypes.number,
+    height: React.PropTypes.number,
     style: React.PropTypes.object,
     supportClick: React.PropTypes.bool,
     accept: React.PropTypes.string,
@@ -94,8 +96,8 @@ var Dropzone = React.createClass({
     }
 
     var style = this.props.style || {
-      width: this.props.size || 100,
-      height: this.props.size || 100,
+      width: this.props.width || this.props.size || 100,
+      height: this.props.height || this.props.size || 100,
       borderStyle: this.state.isDragActive ? 'solid' : 'dashed'
     };
 


### PR DESCRIPTION
I added an explicit `noDefaultStyles` prop to make it clear what's happening when someone doesn't want to use the default `style` object (for example, when using a custom CSS class). 

I found using `style={{}}` cryptic and unclear for anyone else looking at the code, not to mention that it wasn't obvious that I needed to pass in an empty object to get my CSS working properly in the first place (see https://github.com/paramaggarwal/react-dropzone/issues/42).

I also added separate `width` and `height` props for better, basic, control over the size of the Dropzone element (not everyone wants a square). But I left the original `size` prop for backwards compatibility and as an easy alternative if you *do* want a square.

I reformatted the render return value onto multiple lines to make it easier to read.

Finally, I added additional documentation to the README to cover these new changes.