### PR TITLE
Adding a display name to avoid the component to display as Unknown

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,9 @@
 var React = require('react');
 
 var Dropzone = React.createClass({
+
+  displayName: 'Dropzone',
+
   getDefaultProps: function() {
     return {
       supportClick: true,


### PR DESCRIPTION
Adding a display name to avoid the component to display as Unknown in React Developer Tools

![image](https://cloud.githubusercontent.com/assets/94527/9016752/01409ddc-3799-11e5-9b98-9c3abc9f3ed6.png)
