### PR TITLE
Allow width / height to accept % as strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,8 +22,14 @@ var Dropzone = React.createClass({
     onDragOver: React.PropTypes.func,
     onDragLeave: React.PropTypes.func,
     size: React.PropTypes.number,
-    width: React.PropTypes.number,
-    height: React.PropTypes.number,
+    width: React.PropTypes.oneOfType([
+      React.PropTypes.number, 
+      React.PropTypes.string
+    ]),
+    height: React.PropTypes.oneOfType([
+      React.PropTypes.number, 
+      React.PropTypes.string
+    ]),
     style: React.PropTypes.object,
     supportClick: React.PropTypes.bool,
     accept: React.PropTypes.string,


### PR DESCRIPTION
Hi Param,

Thanks for this react component. :grinning: 

I wanted to provide `width:100%` to the dropzone but it gave a `propType` validation error. Here's a quick fix that allows the width and height of the dropzone to be set in %age (as well as pixels) without giving the `failed Proptype` error.

:beers: 