### PR TITLE
allow passing in custom activeClassName

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,8 @@ var Dropzone = React.createClass({
     style: React.PropTypes.object,
     supportClick: React.PropTypes.bool,
     accept: React.PropTypes.string,
-    multiple: React.PropTypes.bool
+    multiple: React.PropTypes.bool,
+    activeClassName: React.PropTypes.string
   },
 
   onDragLeave: function(e) {
@@ -99,7 +100,7 @@ var Dropzone = React.createClass({
   render: function() {
     var className = this.props.className || 'dropzone';
     if (this.state.isDragActive) {
-      className += ' active';
+      className += this.props.activeClassName || ' active';
     }
 
     var style = {};


### PR DESCRIPTION
### Issue
Right now `react-dropzone` adds a class of `active` while dragging a file over the component. The issue is that due to the global nature of css if you have an `.active` style defined in any other stylesheets it's styles will get applied to the `react-dropzone` instance.

### Solution
Allow passing in the `activeClassName` as a prop this way if you can choose a globally unique classname (by using something like css modules) for the active state.