### PR TITLE
make input a self closing tag and move position of children

### DIFF
--- a/index.js
+++ b/index.js
@@ -142,15 +142,14 @@ var Dropzone = React.createClass({
         onDragLeave={this.onDragLeave}
         onDrop={this.onDrop}
       >
+        {this.props.children}
         <input
           type='file'
           ref='fileInput'
           style={{ display: 'none' }}
           multiple={this.props.multiple}
           onChange={this.onDrop}
-        >
-          {this.props.children}
-        </input>
+        />
       </div>
     );
   }


### PR DESCRIPTION
in react 0.14, a warning is thrown when you pass children to a tag that HTML standards say is self closing. 
![screen shot 2015-09-07 at 12 15 20 pm](https://cloud.githubusercontent.com/assets/8263298/9720291/bd1d5e6c-555a-11e5-8608-a698966c4d41.png)
