### PR TITLE
Make it work in nwjs environment

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,7 +90,7 @@ var Dropzone = React.createClass({
 
     for (var i = 0; i < max; i++) {
       var file = droppedFiles[i];
-      file.preview = URL.createObjectURL(file);
+      file.preview = window.URL.createObjectURL(file);
       files.push(file);
     }
 


### PR DESCRIPTION
Hi, it's just a simple patch to make the component work in NWJS environment.
When using jsx transforms and other react magic in an nwjs app, in certain cases global scopes are mixed up, so I made it explicit that that the `URL` object has to be read from `window` variable, not from node's `global`