### PR TITLE
webpack config + allow for using 'activeStyle' independently of 'style'

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ The easiest way to use react-dropzone is to install it from npm and include it i
 npm install --save react-dropzone
 ```
 
+Create a standalone module using *WebPack*:
+```
+> npm install
+> webpack
+```
+
 Usage
 =====
 

--- a/index.js
+++ b/index.js
@@ -135,9 +135,13 @@ var Dropzone = React.createClass({
     };
 
     var style, activeStyle;
-    if (this.props.style) {
-      style = this.props.style;
-      activeStyle = this.props.activeStyle;
+    if (this.props.style || this.props.activeStyle) {
+      if (this.props.style) {
+        style = this.props.style;
+      }
+      if (this.props.activeStyle) {
+        activeStyle = this.props.activeStyle;
+      }
     } else if (!className) {
       style = {
         width: 200,
@@ -154,7 +158,7 @@ var Dropzone = React.createClass({
     }
 
     var appliedStyle;
-    if (style && this.state.isDragActive) {
+    if (activeStyle && this.state.isDragActive) {
       appliedStyle = {
         ...style,
         ...activeStyle

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,14 @@
+{
+	module.exports = {
+	    entry: "./lib/index.js",
+	    output: {
+	        path: __dirname,
+	        filename: "./dist/react-dropzone.js",
+	        libraryTarget: "var",
+	        library: "Dropzone"
+	    },
+	    externals: {
+	    	"react": "React"
+	    }
+	}
+};


### PR DESCRIPTION
This change allows for setting the 'activeStyle' independently of the 'style'. This is for cases where someone might want to use css classes to define the base style and but use inline-styles for the OnDragOver case.

Also included is a webpack config for building out a module that can be included in a <script> tag (instead of using `require`). 

Thanks!