### PR TITLE
Maintain drag-active state while hovering child elements.

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,12 +34,19 @@ var Dropzone = React.createClass({
     accept: React.PropTypes.string,
   },
 
+  componentDidMount: function() {
+    this.enterCounter = 0;
+  },
+
   allFilesAccepted: function(files) {
     return files.every(file => accept(file, this.props.accept))
   },
 
   onDragEnter: function(e) {
     e.preventDefault();
+
+    // Count the dropzone and any children that are entered.
+    ++this.enterCounter;
 
     // This is tricky. During the drag even the dataTransfer.files is null
     // But Chrome implements some drag store, which is accesible via dataTransfer.items
@@ -66,6 +73,11 @@ var Dropzone = React.createClass({
   onDragLeave: function(e) {
     e.preventDefault();
 
+    // Only deactivate once the dropzone and all children was left.
+    if (--this.enterCounter > 0) {
+      return;
+    }
+
     this.setState({
       isDragActive: false,
       isDragReject: false
@@ -78,6 +90,9 @@ var Dropzone = React.createClass({
 
   onDrop: function(e) {
     e.preventDefault();
+
+    // Reset the counter along with the drag on a drop.
+    this.enterCounter = 0;
 
     this.setState({
       isDragActive: false,


### PR DESCRIPTION
The component works fine with text children, but when DOM elements or components are added as children the hover-active state is not maintained since the `onDragLeave` event fires when moving over children.

A solution is complicated by the fact that the order in which the `onDragEnter` and `onDragLeave` events fire on the top most element and its children is non-deterministic and depends on the speed with which the mouse moves over the various elements.

However, in the end, once you have left the parent the same number of elements entered must have been left as well, so counting the events on the way in and out turns out to be an effective way to solve the problem.

I'd love to hear your comments.