### PR TITLE
Update index.js to add backward compatibility for react

### DIFF
--- a/index.js
+++ b/index.js
@@ -114,7 +114,13 @@ class Dropzone extends React.Component {
   open() {
     var fileInput = this.refs.fileInput;
     fileInput.value = null;
-    fileInput.click();
+    if (fileInput.click && typeof fileInput.click === 'function'){
+      fileInput.click();
+    }
+    else {
+    fileInput.getDOMNode().click();
+  }
+  
   }
 
   render() {


### PR DESCRIPTION
React ref are not point to the Native DOM before 0.14
so this.refs.fileInput.click() will not work and will throw TypeError in version before v0.14