### PR TITLE
Add disablePreview prop to support big files that don't need preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Features
 - `multiple` - To accept only a single file, set this to `false`.
 
 To show a preview of the dropped file while it uploads, use the `file.preview` property. Use `<img src={file.preview} />` to display a preview of the image dropped.
+You can disable the creation of the preview (for example if you drop big files) by setting the `disablePreview` prop to `true`.
 
 To trigger the dropzone manually (open the file prompt), call the component's `open` function.
 

--- a/index.js
+++ b/index.js
@@ -86,7 +86,10 @@ class Dropzone extends React.Component {
 
     for (var i = 0; i < max; i++) {
       var file = droppedFiles[i];
-      file.preview = window.URL.createObjectURL(file);
+      // We might want to disable the preview creation to support big files
+      if (!this.disablePreview) {
+        file.preview = window.URL.createObjectURL(file);
+      }
       files.push(file);
     }
 
@@ -208,6 +211,7 @@ class Dropzone extends React.Component {
 }
 
 Dropzone.defaultProps = {
+  disablePreview: false,
   disableClick: false,
   multiple: true
 };
@@ -226,6 +230,7 @@ Dropzone.propTypes = {
   activeClassName: React.PropTypes.string,
   rejectClassName: React.PropTypes.string,
 
+  disablePreview: React.PropTypes.bool,
   disableClick: React.PropTypes.bool,
   multiple: React.PropTypes.bool,
   accept: React.PropTypes.string,


### PR DESCRIPTION
I am using this component to hash files in the browser.
Because hashing a file is a streaming process, it doesn't need to read the whole file to process it : thus I can drop bigger files in the drop zone.
Unfortunately right now the preview creation inside the component makes it impossible to handle big files (>100Mo)