### PR TITLE
Support additional props on root element and file input

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,28 +124,35 @@ class Dropzone extends React.Component {
   }
 
   render() {
-    let className, style, activeStyle, rejectStyle;
+    const {
+      accept,
+      activeClassName,
+      inputProps,
+      multiple,
+      name,
+      rejectClassName,
+      ...rest
+    } = this.props;
+    let {
+      activeStyle,
+      className,
+      rejectStyle,
+      style,
+      ...props
+    } = rest;
 
-    className = this.props.className || '';
+    let { isDragActive, isDragReject } = this.state;
 
-    if (this.state.isDragActive && this.props.activeClassName) {
-      className += ' ' + this.props.activeClassName;
+    className = className || '';
+
+    if (isDragActive && activeClassName) {
+      className += ' ' + activeClassName;
     }
-    if (this.state.isDragReject && this.props.rejectClassName) {
-      className += ' ' + this.props.rejectClassName;
+    if (isDragReject && rejectClassName) {
+      className += ' ' + rejectClassName;
     }
 
-    if (this.props.style || this.props.activeStyle || this.props.rejectStyle) {
-      if (this.props.style) {
-        style = this.props.style;
-      }
-      if (this.props.activeStyle) {
-        activeStyle = this.props.activeStyle;
-      }
-      if (this.props.rejectStyle) {
-        rejectStyle = this.props.rejectStyle;
-      }
-    } else if (!className) {
+    if (!className && !style && !activeStyle && !rejectStyle) {
       style = {
         width: 200,
         height: 200,
@@ -165,38 +172,42 @@ class Dropzone extends React.Component {
     }
 
     let appliedStyle;
-    if (activeStyle && this.state.isDragActive) {
+    if (activeStyle && isDragActive) {
       appliedStyle = {
         ...style,
         ...activeStyle
       };
     }
-  else if (rejectStyle && this.state.isDragReject) {
+    else if (rejectStyle && isDragReject) {
       appliedStyle = {
         ...style,
         ...rejectStyle
       };
-  } else {
+    } else {
       appliedStyle = {
         ...style
       };
     }
 
+
     const inputAttributes = {
+      accept,
       type: 'file',
       style: { display: 'none'},
+      multiple: supportMultiple && multiple,
       ref: 'fileInput',
-      accept: this.props.accept,
       onChange: this.onDrop
     };
 
-    supportMultiple && (inputAttributes.multiple = this.props.multiple);
-    this.props.name && (inputAttributes.name = this.props.name);
+    if (name && name.length) {
+      inputAttributes.name = name;
+    }
 
     return (
       <div
         className={className}
         style={appliedStyle}
+        {...props /* expand user provided props first so event handlers are never overridden */}
         onClick={this.onClick}
         onDragEnter={this.onDragEnter}
         onDragOver={this.onDragOver}
@@ -204,7 +215,10 @@ class Dropzone extends React.Component {
         onDrop={this.onDrop}
       >
         {this.props.children}
-        <input {...inputAttributes} />
+        <input
+          {...inputProps /* expand user provided inputProps first so inputAttributes override them */}
+          {...inputAttributes}
+          />
       </div>
     );
   }
@@ -232,6 +246,8 @@ Dropzone.propTypes = {
 
   disablePreview: React.PropTypes.bool,
   disableClick: React.PropTypes.bool,
+
+  inputProps: React.PropTypes.object,
   multiple: React.PropTypes.bool,
   accept: React.PropTypes.string,
   name: React.PropTypes.string

--- a/mocha-environment.js
+++ b/mocha-environment.js
@@ -1,5 +1,5 @@
 // import es6
-require('babel-core/register');
+require('babel/register');
 
 // jsdom
 var jsdom = require('jsdom');

--- a/package.json
+++ b/package.json
@@ -45,6 +45,8 @@
     "mocha": "^2.3.4",
     "react": "^0.14.3",
     "react-addons-test-utils": "^0.14.3",
+    "react-dom": "^0.14.3",
+    "react-testutils-additions": "^0.2.0",
     "sinon": "^1.17.2"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,7 +1,7 @@
 import React from "react";
 import {expect} from 'chai';
 import {spy} from 'sinon';
-import TestUtils from "react-addons-test-utils";
+import TestUtils from "react-testutils-additions";
 import Dropzone from "./index";
 
 describe('Dropzone', () => {
@@ -32,13 +32,54 @@ describe('Dropzone', () => {
     expect(dropSpy.firstCall.args[0][0]).to.have.property('preview');
   });
 
-  it('uses the disablePreview property', () => {
-    let dropSpy = spy();
-    let dropzone = TestUtils.renderIntoDocument(<Dropzone disablePreview={true} onDrop={dropSpy}><div className="dropzone-content">some content</div></Dropzone>);
-    let content = TestUtils.findRenderedDOMComponentWithClass(dropzone, 'dropzone-content');
+  describe('props', () => {
 
-    TestUtils.Simulate.drop(content, { dataTransfer: { files } });
-    expect(dropSpy.callCount).to.equal(1);
-    expect(dropSpy.firstCall.args[0][0]).to.not.have.property('preview');
+    it('uses the disablePreview property', () => {
+      let dropSpy = spy();
+      let dropzone = TestUtils.renderIntoDocument(<Dropzone disablePreview={true} onDrop={dropSpy}><div className="dropzone-content">some content</div></Dropzone>);
+      let content = TestUtils.findRenderedDOMComponentWithClass(dropzone, 'dropzone-content');
+
+      TestUtils.Simulate.drop(content, { dataTransfer: { files } });
+      expect(dropSpy.callCount).to.equal(1);
+      expect(dropSpy.firstCall.args[0][0]).to.not.have.property('preview');
+    });
+
+    it('renders dynamic props on the root element', () => {
+      let component = TestUtils.renderIntoDocument(<Dropzone hidden={true} aria-hidden="hidden" title="Dropzone" />);
+      expect(TestUtils.find(component, '[hidden][aria-hidden="hidden"][title="Dropzone"]')).to.have.length(1);
+    });
+
+    it('renders dynamic props on the input element', () => {
+      let component = TestUtils.renderIntoDocument(<Dropzone inputProps={{ id: 'hiddenFileInput'} } />);
+      expect(TestUtils.find(component, '#hiddenFileInput')).to.have.length(1);
+    });
+
+    it('applies the accept prop to the child input', () => {
+      let component = TestUtils.renderIntoDocument(<Dropzone className="my-dropzone" accept="image/jpeg" />);
+      expect(TestUtils.find(component, 'input[type="file"][accept="image/jpeg"]')).to.have.length(1);
+      expect(TestUtils.find(component, '[class="my-dropzone"][accept="image/jpeg"]')).to.have.length(0);
+    });
+
+    it('applies the name prop to the child input', () => {
+      let component = TestUtils.renderIntoDocument(<Dropzone className="my-dropzone" name="test-file-input" />);
+      expect(TestUtils.find(component, 'input[type="file"][name="test-file-input"]')).to.have.length(1);
+      expect(TestUtils.find(component, '[class="my-dropzone"][name="test-file-input"]')).to.have.length(0);
+    });
+
+    it('does not apply the name prop if name is falsey', () => {
+      let component = TestUtils.renderIntoDocument(<Dropzone className="my-dropzone" name="" />);
+      expect(TestUtils.find(component, 'input[type="file"][name]')).to.have.length(0);
+    });
+
+    it('overrides onClick', () => {
+      let clickSpy = spy();
+      let component = TestUtils.renderIntoDocument(<Dropzone id="example" onClick={clickSpy} />);
+      let content = TestUtils.find(component, '#example')[0];
+
+      TestUtils.Simulate.click(content);
+      expect(clickSpy).to.not.be.called;
+    });
+
   });
+
 });


### PR DESCRIPTION
Fixes #108

- Add support for dynamic props on root element
- Add support for dynamic props on input element (via inputProps prop)
- Write basic tests for dynamic props
- Added `react-testutils-additions` as a dev dependency, for $ style find selectors

- Fix babel reference in mocha-environment (could not run tests from a clean install otherwise)
- Fix babel reference in npm build script to use local installed babel